### PR TITLE
Improve megarules for urgent response

### DIFF
--- a/add_user_rules.py
+++ b/add_user_rules.py
@@ -182,32 +182,6 @@ def submit_iterator_job(projectName, rule_name, workflow, priority, query_string
 
     # ensure GRQ product index mappings exist in percolator index
     add_grq_mappings(es_url, es_index)
-
-    # # query
-    # query = {
-    #     "query": {
-    #         "bool": {
-    #             "must": [
-    #                 { "term": { "username": user_name }  },
-    #                 { "term": { "rule_name": rule_name } },
-    #             ]
-    #         }
-    #     }
-    # }
-    # r = requests.post('%s/%s/.percolator/_search' % (es_url, es_index), data=json.dumps(query))
-    # result = r.json()
-    # if r.status_code != 200:
-    #     logger.debug("Failed to query ES. Got status code %d:\n%s" %
-    #                      (r.status_code, json.dumps(result, indent=2)))
-    # r.raise_for_status()
-    # if result['hits']['total'] == 1:
-    #     logger.debug("Found a rule using that name already: %s" % rule_name)
-    #     return json.dumps({
-    #         'success': False,
-    #         'message': "Found a rule using that name already: %s" % rule_name,
-    #         'result': None,
-    #     }), 500
-
     job_type = None
     passthru_query = False
     query_all = False

--- a/docker/hysds-io.json.lw-tosca-AOI_mega_rules
+++ b/docker/hysds-io.json.lw-tosca-AOI_mega_rules
@@ -100,7 +100,7 @@
       "name": "slcp_product_version",
       "from": "submitter",
       "type": "text",
-      "default": "v1.3"
+      "default": "v1.2"
     },
     {
       "name": "LAR_workflow_version",

--- a/docker/hysds-io.json.lw-tosca-AOI_mega_rules
+++ b/docker/hysds-io.json.lw-tosca-AOI_mega_rules
@@ -77,7 +77,7 @@
       "name": "slcp_product_version",
       "from": "submitter",
       "type": "text",
-      "default": "v1.2"
+      "default": "v1.3"
     },
     {
       "name": "LAR_workflow_version",
@@ -111,7 +111,8 @@
       "name": "temporal_baseline",
       "type": "text",
       "from": "submitter",
-      "placeholder":"no. of days to look back for product pairs"
+      "placeholder":"no. of days to look back for product pairs",
+      "default": "24"
     },
     {
       "name": "query",
@@ -122,10 +123,11 @@
       "name": "minimum_pair",
       "from": "submitter",
       "type": "text",
-      "placeholder":"min no. of pairs guaranteed to be processed"
+      "placeholder":"min no. of pairs guaranteed to be processed",
+      "default": "1"
     },
     {
-      "name": "range_looks",
+      "name": "ifg_range_looks",
       "from": "submitter",
       "type": "number",
       "placeholder": "input for IFG",
@@ -133,12 +135,44 @@
       "default": "7"
     },
     {
-      "name": "azimuth_looks",
+      "name": "ifg_azimuth_looks",
       "from": "submitter",
       "type": "number",
       "placeholder": "input for IFG",
       "optional": true,
       "default": "3"
+    },
+    {
+      "name": "lar_range_looks",
+      "from": "submitter",
+      "type": "number",
+      "placeholder": "input for LAR",
+      "optional": true,
+      "default": "7"
+    },
+    {
+      "name": "lar_azimuth_looks",
+      "from": "submitter",
+      "type": "number",
+      "placeholder": "input for LAR, one value across all subswaths",
+      "optional": true,
+      "default": "2"
+    },
+    {
+      "name": "cod_range_looks",
+      "from": "submitter",
+      "type": "text",
+      "placeholder": "input for COD (comma sep. s1,s2,s3)",
+      "optional": true,
+      "default": "16,16,16"
+    },
+    {
+      "name": "cod_azimuth_looks ",
+      "from": "submitter",
+      "type": "text",
+      "placeholder": "input for COD (comma sep s1,s2,s3)",
+      "optional": true,
+      "default": "4,4,4"
     },
     { 
       "name": "filter_strength",

--- a/docker/hysds-io.json.lw-tosca-AOI_mega_rules
+++ b/docker/hysds-io.json.lw-tosca-AOI_mega_rules
@@ -67,6 +67,29 @@
       "value": "hysds-io-slcp2cod_network_selector"
     },
     {
+      "name": "IFG_workflow_version",
+      "from": "submitter",
+      "type": "jobspec_version",
+      "version_regex": "job-sciflo-s1-ifg",
+      "placeholder": "ifg job version"
+    },
+    {
+      "name": "ifg_range_looks",
+      "from": "submitter",
+      "type": "number",
+      "placeholder": "input for IFG",
+      "optional": true,
+      "default": "7"
+    },
+    {
+      "name": "ifg_azimuth_looks",
+      "from": "submitter",
+      "type": "number",
+      "placeholder": "input for IFG",
+      "optional": true,
+      "default": "3"
+    },
+    {
       "name": "SLCP_workflow_version",
       "from": "submitter",
       "type": "jobspec_version",
@@ -87,11 +110,20 @@
       "placeholder": "lar job version"
     },
     {
-      "name": "IFG_workflow_version",
+      "name": "lar_range_looks",
       "from": "submitter",
-      "type": "jobspec_version",
-      "version_regex": "job-sciflo-s1-ifg",
-      "placeholder": "ifg job version"
+      "type": "number",
+      "placeholder": "input for LAR",
+      "optional": true,
+      "default": "7"
+    },
+    {
+      "name": "lar_azimuth_looks",
+      "from": "submitter",
+      "type": "number",
+      "placeholder": "input for LAR, one value across all subswaths",
+      "optional": true,
+      "default": "2"
     },
     {
       "name": "COD_workflow_version",
@@ -99,6 +131,22 @@
       "type": "jobspec_version",
       "version_regex": "job-slcp2cod_network_selector",
       "placeholder": "cod job version"
+    },
+    {
+      "name": "cod_range_looks",
+      "from": "submitter",
+      "type": "text",
+      "placeholder": "input for COD (comma sep. s1,s2,s3)",
+      "optional": true,
+      "default": "16,16,16"
+    },
+    {
+      "name": "cod_azimuth_looks ",
+      "from": "submitter",
+      "type": "text",
+      "placeholder": "input for COD (comma sep s1,s2,s3)",
+      "optional": true,
+      "default": "4,4,4"
     },
     {
       "name": "track_number",
@@ -125,54 +173,6 @@
       "type": "text",
       "placeholder":"min no. of pairs guaranteed to be processed",
       "default": "1"
-    },
-    {
-      "name": "ifg_range_looks",
-      "from": "submitter",
-      "type": "number",
-      "placeholder": "input for IFG",
-      "optional": true,
-      "default": "7"
-    },
-    {
-      "name": "ifg_azimuth_looks",
-      "from": "submitter",
-      "type": "number",
-      "placeholder": "input for IFG",
-      "optional": true,
-      "default": "3"
-    },
-    {
-      "name": "lar_range_looks",
-      "from": "submitter",
-      "type": "number",
-      "placeholder": "input for LAR",
-      "optional": true,
-      "default": "7"
-    },
-    {
-      "name": "lar_azimuth_looks",
-      "from": "submitter",
-      "type": "number",
-      "placeholder": "input for LAR, one value across all subswaths",
-      "optional": true,
-      "default": "2"
-    },
-    {
-      "name": "cod_range_looks",
-      "from": "submitter",
-      "type": "text",
-      "placeholder": "input for COD (comma sep. s1,s2,s3)",
-      "optional": true,
-      "default": "16,16,16"
-    },
-    {
-      "name": "cod_azimuth_looks ",
-      "from": "submitter",
-      "type": "text",
-      "placeholder": "input for COD (comma sep s1,s2,s3)",
-      "optional": true,
-      "default": "4,4,4"
     },
     { 
       "name": "filter_strength",

--- a/docker/hysds-io.json.lw-tosca-AOI_mega_rules
+++ b/docker/hysds-io.json.lw-tosca-AOI_mega_rules
@@ -191,7 +191,7 @@
       "type": "number",
       "placeholder": "coverage required to match pairs",
       "optional": false,
-      "default": "0.20"
+      "default": "0.30"
     },
     {
       "name": "dataset_tag",

--- a/docker/hysds-io.json.lw-tosca-AOI_mega_rules
+++ b/docker/hysds-io.json.lw-tosca-AOI_mega_rules
@@ -140,7 +140,7 @@
       "default": "16,16,16"
     },
     {
-      "name": "cod_azimuth_looks ",
+      "name": "cor_azimuth_looks ",
       "from": "submitter",
       "type": "text",
       "placeholder": "input for COD (comma sep s1,s2,s3)",

--- a/docker/hysds-io.json.lw-tosca-AOI_mega_rules
+++ b/docker/hysds-io.json.lw-tosca-AOI_mega_rules
@@ -140,7 +140,7 @@
       "default": "16,16,16"
     },
     {
-      "name": "cor_azimuth_looks ",
+      "name": "cod_azimuth_looks",
       "from": "submitter",
       "type": "text",
       "placeholder": "input for COD (comma sep s1,s2,s3)",

--- a/docker/hysds-io.json.lw-tosca-AOI_mega_rules
+++ b/docker/hysds-io.json.lw-tosca-AOI_mega_rules
@@ -137,7 +137,6 @@
       "from": "submitter",
       "type": "text",
       "placeholder": "input for COD (comma sep. s1,s2,s3)",
-      "optional": true,
       "default": "16,16,16"
     },
     {
@@ -145,7 +144,6 @@
       "from": "submitter",
       "type": "text",
       "placeholder": "input for COD (comma sep s1,s2,s3)",
-      "optional": true,
       "default": "4,4,4"
     },
     {

--- a/docker/job-spec.json.lw-tosca-AOI_mega_rules
+++ b/docker/job-spec.json.lw-tosca-AOI_mega_rules
@@ -88,7 +88,7 @@
       "destination": "context"
     },
     {
-      "name": "cod_azimuth_looks",
+      "name": "cor_azimuth_looks",
       "destination": "context"
     },
     {

--- a/docker/job-spec.json.lw-tosca-AOI_mega_rules
+++ b/docker/job-spec.json.lw-tosca-AOI_mega_rules
@@ -88,7 +88,7 @@
       "destination": "context"
     },
     {
-      "name": "cor_azimuth_looks",
+      "name": "cod_azimuth_looks",
       "destination": "context"
     },
     {

--- a/docker/job-spec.json.lw-tosca-AOI_mega_rules
+++ b/docker/job-spec.json.lw-tosca-AOI_mega_rules
@@ -84,11 +84,35 @@
       "destination": "context"
     },
     {
-      "name": "range_looks",
+      "name": "ifg_range_looks",
       "destination": "context"
     },
     {
-      "name": "azimuth_looks",
+      "name": "ifg_azimuth_looks",
+      "destination": "context"
+    },
+    {
+      "name": "slcp_range_looks",
+      "destination": "context"
+    },
+    {
+      "name": "slcp_azimuth_looks",
+      "destination": "context"
+    },
+    {
+      "name": "lar_range_looks",
+      "destination": "context"
+    },
+    {
+      "name": "lar_azimuth_looks",
+      "destination": "context"
+    },
+    {
+      "name": "cod_range_looks",
+      "destination": "context"
+    },
+    {
+      "name": "cod_azimuth_looks",
       "destination": "context"
     },
     { 

--- a/docker/job-spec.json.lw-tosca-AOI_mega_rules
+++ b/docker/job-spec.json.lw-tosca-AOI_mega_rules
@@ -92,14 +92,6 @@
       "destination": "context"
     },
     {
-      "name": "slcp_range_looks",
-      "destination": "context"
-    },
-    {
-      "name": "slcp_azimuth_looks",
-      "destination": "context"
-    },
-    {
       "name": "lar_range_looks",
       "destination": "context"
     },

--- a/docker/job-spec.json.lw-tosca-AOI_mega_rules
+++ b/docker/job-spec.json.lw-tosca-AOI_mega_rules
@@ -48,6 +48,18 @@
       "destination": "context"
     },
     {
+      "name": "IFG_workflow_version",
+      "destination": "context"
+    },
+    {
+      "name": "ifg_range_looks",
+      "destination": "context"
+    },
+    {
+      "name": "ifg_azimuth_looks",
+      "destination": "context"
+    },
+    {
       "name": "SLCP_workflow_version",
       "destination": "context"
     },
@@ -60,11 +72,23 @@
       "destination": "context"
     },
     {
-      "name": "IFG_workflow_version",
+      "name": "lar_range_looks",
+      "destination": "context"
+    },
+    {
+      "name": "lar_azimuth_looks",
       "destination": "context"
     },
     {
       "name": "COD_workflow_version",
+      "destination": "context"
+    },
+    {
+      "name": "cod_range_looks",
+      "destination": "context"
+    },
+    {
+      "name": "cod_azimuth_looks",
       "destination": "context"
     },
     {
@@ -81,30 +105,6 @@
     },
     {
       "name": "minimum_pair",
-      "destination": "context"
-    },
-    {
-      "name": "ifg_range_looks",
-      "destination": "context"
-    },
-    {
-      "name": "ifg_azimuth_looks",
-      "destination": "context"
-    },
-    {
-      "name": "lar_range_looks",
-      "destination": "context"
-    },
-    {
-      "name": "lar_azimuth_looks",
-      "destination": "context"
-    },
-    {
-      "name": "cod_range_looks",
-      "destination": "context"
-    },
-    {
-      "name": "cod_azimuth_looks",
       "destination": "context"
     },
     { 

--- a/megarules.py
+++ b/megarules.py
@@ -187,7 +187,7 @@ def add_rule(mode, open_ended, AOI_name, coordinates, workflow_params, projectNa
         other_params = {"event_time":event_time, "start_time":start_time, "end_time":end_time, "dataset_tag":dataset_tag, "project":projectName, "singlesceneOnly": "true", "temporalBaseline":temporal_baseline, "minMatch":minMatch, "covth":coverage_threshold, "precise_orbit_only":"false", "azimuth_looks":azimuth_looks, "filter_strength":filter_strength, "dem_type":dem_type, "range_looks":range_looks}
     elif workflow.find("cod") != -1:
         event_rule = rule_generation(open_ended, '"S1-SLCP"', track_number, start_time, end_time, coordinates, passthrough)
-        other_params = {"dataset_tag":dataset_tag, "project": projectName, "slcp_version":slcp_product_version, "temporal_baseline": temporal_baseline, "aoi_name":AOI_name, "overriding_azimuth_looks":azimuth_looks, "overriding_range_looks":range_looks, "track_number": track_number}
+        other_params = {"dataset_tag":dataset_tag, "project": projectName, "slcp_version":slcp_product_version, "temporal_baseline": temporal_baseline, "aoi_name":AOI_name, "overriding_azimuth_looks":azimuth_looks, "overriding_range_looks":range_looks, "track_number": track_number, "minmatch":minMatch,  "min_overlap":coverage_threshold}
 
     logger.debug("Going to add "+mode+"rule for "+workflow)
     logger.debug("Rule names: %s"% rule_name)

--- a/megarules.py
+++ b/megarules.py
@@ -54,7 +54,7 @@ def submit_jobs(job_name, job_type, release, job_params, condition, dataset_tag)
     job = job_type[job_type.find("hysds-io-")+9:]
     params = {}
     params["queue"] = job_params["project"]+"-job_worker-small"
-    params["priority"] = "5"
+    params["priority"] = "9"
     params["name"] = job_name
     params["tags"] = '["%s"]' % dataset_tag
     params["type"] = 'job-%s:%s' % (job, release)
@@ -227,7 +227,7 @@ def add_rule(mode, open_ended, AOI_name, coordinates, workflow_params, projectNa
 
     return rules_info
 
-def add_co_event_lar(event_rule, projectName, AOI_name, workflow_params, priority):
+def add_co_event_lar(event_rule, projectName, AOI_name, workflow_params, dataset_tag, priority):
     #mode can be pre-event-, post-event- or ''(in the case of monitoring)
     workflow = workflow_params['workflow']
     workflow_version = workflow_params['workflow_version']
@@ -266,6 +266,7 @@ def add_co_event_lar(event_rule, projectName, AOI_name, workflow_params, priorit
     logger.debug(mode+"rule added")
     print(mode+"rule added")
 
+    submit_jobs(rule_name, workflow, workflow_version, other_params, event_rule, dataset_tag)
     return rules_info
 
 
@@ -352,7 +353,7 @@ def mega_rules(AOI_name, coordinates, slcp_rule, lar_rule, ifg_rule, cod_rule, s
                 rule_names.extend([AOI_name+"-slcp_email"])
             if lar_rule == True:
                 event_rule = co_event_rule(passthrough, "S1-SLCP", track_number, event_time, coordinates)
-                rules_info += add_co_event_lar(event_rule, projectName, AOI_name, lar_params, 7)
+                rules_info += add_co_event_lar(event_rule, projectName, AOI_name, lar_params, dataset_tag, 7)
                 rule_names.extend(["co-event-lar_"+AOI_name])
                 #add email rule
                 rules_info += add_email_rule(AOI_name, "S1-LAR", track_number, passthrough, event_time, coordinates, emails)
@@ -406,7 +407,7 @@ def mega_rules(AOI_name, coordinates, slcp_rule, lar_rule, ifg_rule, cod_rule, s
 
             if lar_rule == True:
                 event_rule = co_event_rule(passthrough, "S1-SLCP", track_number, event_time, coordinates)
-                rules_info += add_co_event_lar(event_rule, projectName, AOI_name, lar_params, 7)
+                rules_info += add_co_event_lar(event_rule, projectName, AOI_name, lar_params, dataset_tag, 7)
                 rule_names.extend(["co-event-lar_"+AOI_name])
                 #add email rule
                 rules_info += add_email_rule(AOI_name, "S1-LAR", track_number, passthrough, event_time, coordinates, emails)

--- a/megarules.py
+++ b/megarules.py
@@ -282,45 +282,47 @@ def add_co_event_lar(event_rule, projectName, AOI_name, workflow_params, dataset
 
 
 def add_email_rule(AOI_name, dataset, track_number, passthrough, event_time, coordinates, emails):
+    if emails:
+        if dataset == "S1-SLCP":
+            product_type = "slcp"
+        elif dataset == "S1-IFG":
+            product_type = "ifg"
+        elif dataset == "S1-LAR":
+            product_type = "lar"
+        elif dataset == "S1-COD":
+            product_type = "cod"
 
-    if dataset == "S1-SLCP":
-        product_type = "slcp"
-    elif dataset == "S1-IFG":
-        product_type = "ifg"
-    elif dataset == "S1-LAR":
-        product_type = "lar"
-    elif dataset == "S1-COD":
-        product_type = "cod"
+        email_rule_set = co_event_rule(passthrough, dataset, track_number, event_time, json.dumps(coordinates))
+        other_params = {"emails": emails}
 
-    email_rule_set = co_event_rule(passthrough, dataset, track_number, event_time, json.dumps(coordinates))
-    other_params = {"emails": emails}
+        logger.debug("Going to add email notification rule for co-seismic products")
+        logger.debug("Rule name: %s", AOI_name+"-"+product_type+"_email")
+        logger.debug("workflow: %s", notify_by_email_io+":"+email_job_version)
+        logger.debug("priority: %s", '0')
+        logger.debug("email_rule_set: %s",email_rule_set)
+        logger.debug("other params: %s", other_params)
+        logger.debug("Event notification rule added")
 
-    logger.debug("Going to add email notification rule for co-seismic products")
-    logger.debug("Rule name: %s", AOI_name+"-"+product_type+"_email")
-    logger.debug("workflow: %s", notify_by_email_io+":"+email_job_version)
-    logger.debug("priority: %s", '0')
-    logger.debug("email_rule_set: %s",email_rule_set)
-    logger.debug("other params: %s", other_params)
-    logger.debug("Event notification rule added")
+        rules_info = "Added email notification rule for co-seismic products\n"
+        rules_info += "Rule name: %s"%AOI_name+"-"+product_type+"_email"+'\n'
+        rules_info += "workflow: %s"% notify_by_email_io+":"+email_job_version+'\n'
+        rules_info += "priority: %s"% '0\n'
+        rules_info += "email notification rule: %s"%email_rule_set+"\n"
+        rules_info +="other params: %s"%other_params+'\n'
 
-    rules_info = "Added email notification rule for co-seismic products\n"
-    rules_info += "Rule name: %s"%AOI_name+"-"+product_type+"_email"+'\n'
-    rules_info += "workflow: %s"% notify_by_email_io+":"+email_job_version+'\n'
-    rules_info += "priority: %s"% '0\n'
-    rules_info += "email notification rule: %s"%email_rule_set+"\n"
-    rules_info +="other params: %s"%other_params+'\n'
+        print("Going to add email notification rule for co-seismic products")
+        print("Rule name: %s", AOI_name+"-"+product_type+"_email")
+        print("workflow: %s", notify_by_email_io+":"+email_job_version)
+        print("priority: %s", '0')
+        print("email_rule_set: %s",email_rule_set)
+        print("other params: %s", other_params)
+        add_user_rules.add_user_rule(projectName, AOI_name+"-"+product_type+"_email", notify_by_email_io+":"+email_job_version, 0, email_rule_set, other_params)
+        logger.debug("Event notification rule added")
+        print("Event notification rule added")
 
-    print("Going to add email notification rule for co-seismic products")
-    print("Rule name: %s", AOI_name+"-"+product_type+"_email")
-    print("workflow: %s", notify_by_email_io+":"+email_job_version)
-    print("priority: %s", '0')
-    print("email_rule_set: %s",email_rule_set)
-    print("other params: %s", other_params)
-    add_user_rules.add_user_rule(projectName, AOI_name+"-"+product_type+"_email", notify_by_email_io+":"+email_job_version, 0, email_rule_set, other_params)
-    logger.debug("Event notification rule added")
-    print("Event notification rule added")
-        
-    return rules_info
+        return rules_info
+    else:
+        return "No emails specified, skipping event notification."
 
 def mega_rules(AOI_name, coordinates, slcp_rule, lar_rule, ifg_rule, cod_rule, slcp_params, lar_params, ifg_params, cod_params, projectName, start_time, end_time, event_time, temporal_baseline, track_number, passthrough, minMatch, filter_strength, dem_type, coverage_threshold, dataset_tag, emails):
 

--- a/megarules.py
+++ b/megarules.py
@@ -475,8 +475,8 @@ if __name__ == "__main__":
 
     slcp_params['workflow']= ctx['slcp_workflow']
     slcp_params['workflow_version'] = ctx['SLCP_workflow_version']
-    slcp_params['azimuth_looks'] = 0
-    slcp_params['range_looks'] = 0
+    slcp_params['azimuth_looks'] = 3 # use default values as it should not matter
+    slcp_params['range_looks'] = 7 # use default values as it should not matter
 
     lar_params['workflow'] = ctx['lar_workflow']
     lar_params['workflow_version'] = ctx['LAR_workflow_version']

--- a/megarules.py
+++ b/megarules.py
@@ -15,7 +15,7 @@ logger = logging.getLogger("hysds")
 
 #manually update this block when there is unsync with avaliable version of email and slcp product version
 notify_by_email_io = "hysds-io-lw-tosca-notify-by-email"
-email_job_version = "release-20170510"
+email_job_version = "v0.0.3"
 admin_email = "grfn-ops@jpl.nasa.gov"
 slcp_product_version = None #look at ariamh/conf/dataset_versions.json under the correct release version
 user_name = None
@@ -273,7 +273,7 @@ def add_co_event_lar(event_rule, projectName, AOI_name, workflow_params, dataset
     logger.debug(mode+"rule added")
     print(mode+"rule added")
 
-    add_user_rules.submit_iterator_job("tosca", event_rule)
+    add_user_rules.submit_iterator_job(projectName, rule_name, workflow_name, priority, event_rule, other_params)
     # submit_jobs(rule_name, workflow, workflow_version, other_params, event_rule, dataset_tag)
     return rules_info
 

--- a/megarules.py
+++ b/megarules.py
@@ -45,6 +45,12 @@ def email_to_user(emails, project_name, rule_names, rules_info):
     logger.info("Email sent to %s",emails)
     print ("Email sent to %s",emails)
 
+def submit_iterate_job(job_name, job_type, release, job_params, condition, dataset_tag):
+    job_params["query"] = {"query": json.loads(condition)}
+    job_params[""]
+
+
+
 def submit_jobs(job_name, job_type, release, job_params, condition, dataset_tag):
     # submit mozart job
     MOZART_URL = app.conf['MOZART_URL']
@@ -267,7 +273,8 @@ def add_co_event_lar(event_rule, projectName, AOI_name, workflow_params, dataset
     logger.debug(mode+"rule added")
     print(mode+"rule added")
 
-    submit_jobs(rule_name, workflow, workflow_version, other_params, event_rule, dataset_tag)
+    add_user_rules.submit_iterator_job("tosca", event_rule)
+    # submit_jobs(rule_name, workflow, workflow_version, other_params, event_rule, dataset_tag)
     return rules_info
 
 

--- a/megarules.py
+++ b/megarules.py
@@ -178,7 +178,7 @@ def add_rule(mode, open_ended, AOI_name, coordinates, workflow_params, projectNa
 
     if workflow.endswith("lar"):
         event_rule = rule_generation(open_ended, '"S1-SLCP"', track_number, start_time, end_time, coordinates, passthrough)
-        other_params = {"lar_azimuth_looks":azimuth_looks, "lar_range_looks":range_looks}
+        other_params = {"lar_azimuth_looks":azimuth_looks, "lar_range_looks":range_looks, "project":projectName}
     elif workflow.endswith("ifg"):
         event_rule = rule_generation(open_ended, '"S1-IW_SLC"', track_number, start_time, end_time, coordinates, passthrough)
         other_params = {"dataset_tag":dataset_tag,"project":projectName , "singlesceneOnly": "true", "preReferencePairDirection": "backward", "postReferencePairDirection": "forward", "temporalBaseline":temporal_baseline,"minMatch":minMatch, "azimuth_looks":azimuth_looks, "filter_strength":filter_strength, "dem_type":dem_type, "range_looks":range_looks, "covth":coverage_threshold, "precise_orbit_only":"false"}
@@ -232,7 +232,8 @@ def add_co_event_lar(event_rule, projectName, AOI_name, workflow_params, dataset
     workflow = workflow_params['workflow']
     workflow_version = workflow_params['workflow_version']
     other_params = {"lar_azimuth_looks": workflow_params['azimuth_looks'],
-                    "lar_range_looks": workflow_params['range_looks']}
+                    "lar_range_looks": workflow_params['range_looks'],
+                    "project": projectName}
 
     mode = "co-event-"
     workflow_name = workflow+":"+workflow_version

--- a/megarules.py
+++ b/megarules.py
@@ -193,7 +193,10 @@ def add_rule(mode, open_ended, AOI_name, coordinates, workflow_params, projectNa
         other_params = {"event_time":event_time, "start_time":start_time, "end_time":end_time, "dataset_tag":dataset_tag, "project":projectName, "singlesceneOnly": "true", "temporalBaseline":temporal_baseline, "minMatch":minMatch, "covth":coverage_threshold, "precise_orbit_only":"false", "azimuth_looks":azimuth_looks, "filter_strength":filter_strength, "dem_type":dem_type, "range_looks":range_looks}
     elif workflow.find("cod") != -1:
         event_rule = rule_generation(open_ended, '"S1-SLCP"', track_number, start_time, end_time, coordinates, passthrough)
-        other_params = {"dataset_tag":dataset_tag, "project": projectName, "slcp_version":slcp_product_version, "temporal_baseline": temporal_baseline, "aoi_name":AOI_name, "overriding_azimuth_looks":azimuth_looks, "overriding_range_looks":range_looks, "track_number": track_number, "minmatch":minMatch,  "min_overlap":coverage_threshold}
+        other_params = {"dataset_tag":dataset_tag, "project": projectName, "slcp_version":slcp_product_version, "temporal_baseline": temporal_baseline, "aoi_name":AOI_name, "overriding_azimuth_looks":azimuth_looks, "overriding_range_looks":range_looks, "minmatch":minMatch,  "min_overlap":coverage_threshold}
+        other_params['track_number'] = "" if track_number == 'not_specified' else track_number
+
+
 
     logger.debug("Going to add "+mode+"rule for "+workflow)
     logger.debug("Rule names: %s"% rule_name)

--- a/megarules.py
+++ b/megarules.py
@@ -210,7 +210,7 @@ def add_rule(mode, open_ended, AOI_name, coordinates, workflow_params, projectNa
     #rules_info += "event_rule: %s"% event_rule+"\n"
     #rules_info += "other params: %s"% other_params+'\n'
 
-    add_user_rules.add_user_rule(projectName, rule_name, workflow, priority, event_rule, other_params)
+    add_user_rules.add_user_rule(projectName, rule_name, workflow_name, priority, event_rule, other_params)
     logger.debug(mode+"rule added")
     print(mode+"rule added")
 

--- a/megarules.py
+++ b/megarules.py
@@ -193,7 +193,7 @@ def add_rule(mode, open_ended, AOI_name, coordinates, workflow_params, projectNa
         other_params = {"event_time":event_time, "start_time":start_time, "end_time":end_time, "dataset_tag":dataset_tag, "project":projectName, "singlesceneOnly": "true", "temporalBaseline":temporal_baseline, "minMatch":minMatch, "covth":coverage_threshold, "precise_orbit_only":"false", "azimuth_looks":azimuth_looks, "filter_strength":filter_strength, "dem_type":dem_type, "range_looks":range_looks}
     elif workflow.find("cod") != -1:
         event_rule = rule_generation(open_ended, '"S1-SLCP"', track_number, start_time, end_time, coordinates, passthrough)
-        other_params = {"dataset_tag":dataset_tag, "project": projectName, "slcp_version":slcp_product_version, "temporal_baseline": temporal_baseline, "aoi_name":AOI_name, "overriding_azimuth_looks":azimuth_looks, "overriding_range_looks":range_looks, "minmatch":minMatch,  "min_overlap":coverage_threshold}
+        other_params = {"dataset_tag":dataset_tag, "project": projectName, "slcp_version":slcp_product_version, "temporal_baseline": temporal_baseline, "aoi_name":AOI_name, "overriding_azimuth_looks":azimuth_looks, "overriding_range_looks":range_looks, "minmatch":minMatch, "min_overlap":coverage_threshold}
         other_params['track_number'] = "" if track_number == 'not_specified' else track_number
 
 
@@ -371,7 +371,7 @@ def mega_rules(AOI_name, coordinates, slcp_rule, lar_rule, ifg_rule, cod_rule, s
                 rule_names.extend([AOI_name+"-lar_email"])
             if cod_rule == True:
                 # add event rule
-                rules_info += add_rule('event-', False, AOI_name, coordinates, cod_params, projectName, start_time, "", end_time, temporal_baseline, track_number, passthrough, '', '', '', '', dataset_tag, 7)
+                rules_info += add_rule('event-', False, AOI_name, coordinates, cod_params, projectName, start_time, "", end_time, temporal_baseline, track_number, passthrough, minMatch, '', '', coverage_threshold, dataset_tag, 7)
                 rule_names.extend(['event-cod_'+AOI_name])
                 #add mail rule
                 rules_info += add_email_rule(AOI_name, "S1-COD", track_number, passthrough, event_time, coordinates, emails)
@@ -425,7 +425,7 @@ def mega_rules(AOI_name, coordinates, slcp_rule, lar_rule, ifg_rule, cod_rule, s
                 rule_names.extend([AOI_name+"-lar_email"])
 
             if cod_rule == True:
-                rules_info += add_rule('event-', False, AOI_name, coordinates, cod_params, projectName, start_time, '', '', temporal_baseline, track_number, passthrough, '', '', '', '', dataset_tag, 7)
+                rules_info += add_rule('event-', False, AOI_name, coordinates, cod_params, projectName, start_time, "", end_time, temporal_baseline, track_number, passthrough, minMatch, '', '', coverage_threshold, dataset_tag, 7)
                 rule_names.extend(["event-cod_"+AOI_name])
                 #add email rule
                 rules_info += add_email_rule(AOI_name, "S1-COD", track_number, passthrough, event_time, coordinates, emails)


### PR DESCRIPTION
Improve megarules with the following changes:

* expose individual ifg, lar, cod looks settings for each product
* attempt submission of COD and LAR job, to handle case where SLCP stack is present in GRQ
* fix email notification blocker


--> compatible with:
slcp2cod:[release-20190624SG](https://github.com/earthobservatory/slcp2cod/releases/tag/release-20190624SG)
slcp2pm / ariamh (for lar): [v0.0.1.2-sg](https://github.com/earthobservatory/ariamh/releases/tag/v0.0.1.2-sg)

[megarules.log](https://gist.github.com/shitong01/6ea4ecfd22a3085b75175541b801cee6)
Jobs submitted:
![image](https://user-images.githubusercontent.com/6346909/59988490-cc9db500-966d-11e9-9375-b5fab39327b7.png)
![image](https://user-images.githubusercontent.com/6346909/59988516-e3440c00-966d-11e9-9c90-02426b5f3c10.png)
Rules created:
![image](https://user-images.githubusercontent.com/6346909/59988556-040c6180-966e-11e9-907e-52727efa9296.png)
